### PR TITLE
[textCurve] allow creating curves which return only x values. dx and ddx are set to zero.

### DIFF
--- a/include/parametric-curves/text-file.hpp
+++ b/include/parametric-curves/text-file.hpp
@@ -66,21 +66,27 @@ public:
   virtual bool loadTextFile(const std::string& fileName)
   {
     Eigen::MatrixXd data = parametriccurves::utils::readMatrixFromFile(fileName);
-    if(data.cols()!=3*size)
+    if(data.cols()==size)
+    {
+      std::cout<<"Setting derivatives to zero"<<std::endl;
+      posValues = data;
+      velValues.setZero();
+      accValues.setZero();
+    }
+    else if (data.cols()==3*size)
+    {
+      posValues = data.leftCols(size);
+      velValues = data.middleCols(size,size);
+      accValues = data.rightCols(size);
+    }
+    else
     {
       std::cout<<"Unexpected number of columns (expected "<<3*size<<", found "<<data.cols()<<")\n";
       return false;
     }
-    
     this->t_max = timeStep*(double)data.rows();
     this->t_min = 0.0;
-    
-    posValues = data.leftCols(size);
-    velValues = data.middleCols(size,size);
-    accValues = data.rightCols(size);
-    
     x_init = posValues.row(0);
-    
     return true;
   }
 


### PR DESCRIPTION
Currently the text curves require that velocity and acc values be also given. this is not useful.
This is a small amendment, which would allow for tracking only position values, and sets the velocity and acceleration to zero.