### PR TITLE
[textCurve] Fix setZero

### DIFF
--- a/include/parametric-curves/text-file.hpp
+++ b/include/parametric-curves/text-file.hpp
@@ -56,20 +56,21 @@ struct TextFile : public AbstractCurve<Numeric, Point> {
   virtual bool loadTextFile(const std::string& fileName) {
     Eigen::MatrixXd data = parametriccurves::utils::readMatrixFromFile(fileName);
     if (data.cols() == size) {
-      std::cout << "Setting derivatives to zero" << std::endl;
+      std::cout << fileName << ": setting derivatives to zero" << std::endl;
       posValues = data;
-      velValues.setZero(size);
-      accValues.setZero(size);
+      velValues.setZero(data.rows(), size);
+      accValues.setZero(data.rows(), size);
     } else if (data.cols() == 2 * size) {
+      std::cout << fileName << ": setting second derivative to zero" << std::endl;
       posValues = data.leftCols(size);
       velValues = data.rightCols(size);
-      accValues = accValues.setZero(size);
+      accValues = accValues.setZero(data.rows(), size);
     } else if (data.cols() == 3 * size) {
       posValues = data.leftCols(size);
       velValues = data.middleCols(size, size);
       accValues = data.rightCols(size);
     } else {
-      std::cout << "Unexpected number of columns (expected " << 3 * size << ", found " << data.cols() << ")\n";
+      std::cout << "Unexpected number of columns (expected " << size << " or " << 2*size << " or " << 3 * size << ", found " << data.cols() << ")\n";
       return false;
     }
     this->t_max = timeStep * (double)data.rows();

--- a/include/parametric-curves/text-file.hpp
+++ b/include/parametric-curves/text-file.hpp
@@ -70,7 +70,8 @@ struct TextFile : public AbstractCurve<Numeric, Point> {
       velValues = data.middleCols(size, size);
       accValues = data.rightCols(size);
     } else {
-      std::cout << "Unexpected number of columns (expected " << size << " or " << 2*size << " or " << 3 * size << ", found " << data.cols() << ")\n";
+      std::cout << "Unexpected number of columns (expected " << size << " or " << 2 * size << " or " << 3 * size
+                << ", found " << data.cols() << ")\n";
       return false;
     }
     this->t_max = timeStep * (double)data.rows();


### PR DESCRIPTION
My changes in #13 introduced compilation errors. This fixes them. I tested it with sot-talos-balance.
Ideally, there should be unit tests for this, but I do not have time now (and I do not think it is really worth it because this package will be replaced by curves some time soon)